### PR TITLE
Change source_type to aggregation.type in opencensus.

### DIFF
--- a/opencensus/OpenCensus-Metrics.md
+++ b/opencensus/OpenCensus-Metrics.md
@@ -24,7 +24,7 @@ Include these attributes for each metric in addition to creating one for each Op
 |-----|-----|-----|
 |`measure.name`|string|The name of the OpenCensus Measure used by the View|
 |`measure.unit`|string|The unit of the OpenCensus Measure used by the View|
-|`source_type`|string|The type of the OpenCensus aggregation used by the View; one of `Count`, `LastValue`, `Sum`, or `Distribution`|
+|`aggregation.type`|string|The type of the OpenCensus aggregation used by the View; one of `Count`, `LastValue`, `Sum`, or `Distribution`|
 
 At this time, we will not be adding any common attributes, however we must allow for our users to be able to do so. These attributes must be defined by the user when creating their Exporter and will be added to the `common` block of each metrics post to New Relic.
 
@@ -139,7 +139,7 @@ New Relic Metric
         "username": "sally",
         "measure.name": "latency",
         "measure.unit": "ms",
-        "source_type": "Count"
+        "aggregation.type": "Count"
       }
     }
   ]
@@ -208,7 +208,7 @@ New Relic Metric
         "environment": "prod",
         "measure.name": "memory",
         "measure.unit": "bytes",
-        "source_type": "LastValue"
+        "aggregation.type": "LastValue"
       }
     }
   ]
@@ -312,7 +312,7 @@ New Relic Metric
         "username": "sally",
         "measure.name": "logins",
         "measure.unit": "logins",
-        "source_type": "Sum"
+        "aggregation.type": "Sum"
       }
     }
   ]
@@ -450,7 +450,7 @@ New Relic Metrics
         "endpoint": "index",
         "measure.name": "latency",
         "measure.unit": "ms",
-        "source_type": "Distribution"
+        "aggregation.type": "Distribution"
       }
     },
     {
@@ -463,7 +463,7 @@ New Relic Metrics
         "endpoint": "index",
         "measure.name": "latency",
         "measure.unit": "ms",
-        "source_type": "Distribution",
+        "aggregation.type": "Distribution",
         "lower_bound": "-Inf",
         "upper_bound": "1"
       }
@@ -478,7 +478,7 @@ New Relic Metrics
         "endpoint": "index",
         "measure.name": "latency",
         "measure.unit": "ms",
-        "source_type": "Distribution",
+        "aggregation.type": "Distribution",
         "lower_bound": "1",
         "upper_bound": "5"
       }
@@ -493,7 +493,7 @@ New Relic Metrics
         "endpoint": "index",
         "measure.name": "latency",
         "measure.unit": "ms",
-        "source_type": "Distribution",
+        "aggregation.type": "Distribution",
         "lower_bound": "5",
         "upper_bound": "10"
       }
@@ -508,7 +508,7 @@ New Relic Metrics
         "endpoint": "index",
         "measure.name": "latency",
         "measure.unit": "ms",
-        "source_type": "Distribution",
+        "aggregation.type": "Distribution",
         "lower_bound": "10",
         "upper_bound": "Inf"
       }


### PR DESCRIPTION
This PR changes the `source_type` attribute name to be aligned with what is specified in our [guidelines](https://github.com/newrelic/exporter-specs/blob/master/Guidelines.md#naming-conventions).